### PR TITLE
MER-034: bump stellar-xdr to v26.0.0, fix ContractId/Hash type changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -224,12 +224,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -293,6 +287,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "chrono"
@@ -522,6 +527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,9 +610,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expect-test"
@@ -1310,6 +1321,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,15 +1390,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.7.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1386,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1398,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1555,7 +1578,7 @@ dependencies = [
  "soroban-test-wasms",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.9",
  "stellar-xdr",
  "tabwriter",
  "textplots",
@@ -1659,19 +1682,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-xdr"
-version = "22.1.0"
+name = "stellar-strkey"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
 dependencies = [
  "arbitrary",
- "base64 0.13.1",
+ "base64",
+ "cfg_eval",
  "crate-git-revision",
  "escape-bytes",
+ "ethnum",
  "hex",
  "serde",
  "serde_with",
- "stellar-strkey",
+ "sha2",
+ "stellar-strkey 0.0.13",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=26.0.0"
+version = "=27.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ wasmparser = "=0.116.1"
 
 # NB: When updating, also update the version in rs-soroban-env dev-dependencies
 [workspace.dependencies.stellar-xdr]
-version = "=22.1.0"
+version = "=26.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false

--- a/soroban-env-common/Cargo.toml
+++ b/soroban-env-common/Cargo.toml
@@ -15,13 +15,13 @@ crate-git-revision = "0.0.6"
 
 [dependencies]
 soroban-env-macros = { workspace = true }
-stellar-xdr = { workspace = true, default-features = false, features = [ "curr" ] }
+stellar-xdr = { workspace = true, default-features = false, features = [ "alloc" ] }
 wasmi = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true}
 serde = { version = "1.0.192", features = ["derive"], optional = true }
 static_assertions = "1.1.0"
 ethnum = "1.5.0"
-arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
+arbitrary = { version = "1.4", features = ["derive"], optional = true }
 num-traits = {version = "0.2.17", default-features = false}
 num-derive = "0.4.1"
 
@@ -37,7 +37,7 @@ std = ["stellar-xdr/std", "stellar-xdr/base64"]
 serde = ["dep:serde", "stellar-xdr/serde"]
 wasmi = ["dep:wasmi", "dep:wasmparser"]
 testutils = ["dep:arbitrary", "stellar-xdr/arbitrary"]
-next = ["stellar-xdr/next", "soroban-env-macros/next"]
+next = ["soroban-env-macros/next"]
 tracy = ["dep:tracy-client"]
 shallow-val-hash = []
 

--- a/soroban-env-common/src/lib.rs
+++ b/soroban-env-common/src/lib.rs
@@ -102,11 +102,9 @@ pub use num::{I256, U256};
 
 pub use storage_type::StorageType;
 
-// Re-export the XDR definitions of a specific version -- curr or next -- of the xdr crate.
-#[cfg(not(feature = "next"))]
-pub use stellar_xdr::curr as xdr;
-#[cfg(feature = "next")]
-pub use stellar_xdr::next as xdr;
+// Re-export the XDR definitions. As of stellar-xdr v27 the curr/next module split
+// was removed; types live flat at the crate root.
+pub use stellar_xdr as xdr;
 
 // Val is the 64-bit transparent type.
 pub use val::{ConversionError, Tag, Val};

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -74,7 +74,7 @@ more-asserts = "=0.3.1"
 pretty_assertions = "=1.4.0"
 backtrace = "=0.3.71"
 serde_json = "=1.0.108"
-arbitrary = "=1.3.2"
+arbitrary = "1.4"
 lstsq = "=0.5.0"
 nalgebra = { version = "=0.32.3", default-features = false, features = ["std"]}
 wasm-encoder = "=0.36.2"
@@ -84,7 +84,7 @@ k256 = {version = "=0.13.1", default-features = false, features = ["alloc"]}
 p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
-version = "=26.0.0"
+version = "=27.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false
@@ -93,7 +93,7 @@ features = ["arbitrary"]
 [features]
  testutils = ["soroban-env-common/testutils", "recording_mode"]
  backtrace = ["dep:backtrace"]
- next = ["soroban-env-common/next", "stellar-xdr/next"]
+ next = ["soroban-env-common/next"]
  tracy = ["dep:tracy-client", "soroban-env-common/tracy"]
  recording_mode = []
  bench = []

--- a/soroban-env-host/Cargo.toml
+++ b/soroban-env-host/Cargo.toml
@@ -84,7 +84,7 @@ k256 = {version = "=0.13.1", default-features = false, features = ["alloc"]}
 p256 = {version = "0.13.2", default-features = false, features = ["alloc"]}
 
 [dev-dependencies.stellar-xdr]
-version = "=22.1.0"
+version = "=26.0.0"
 #git = "https://github.com/stellar/rs-stellar-xdr"
 #rev = "67be5955a15f1d3a4df83fe86e6ae107f687141b"
 default-features = false

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1304,7 +1304,7 @@ impl AuthorizationManager {
             #[cfg(any(test, feature = "testutils"))]
             Frame::TestContract(tc) => (tc.id.metered_clone(host)?, tc.func),
         };
-        let contract_address = host.add_host_object(ScAddress::Contract(contract_id))?;
+        let contract_address = host.add_host_object(ScAddress::Contract(xdr::ContractId(contract_id)))?;
         Vec::<ContractInvocation>::charge_bulk_init_cpy(1, host)?;
         self.try_borrow_call_stack_mut(host)?
             .push(AuthStackFrame::Contract(ContractInvocation {
@@ -2024,11 +2024,19 @@ impl AccountAuthorizationTracker {
             ScAddress::Contract(acc_contract) => {
                 check_account_contract_auth(
                     host,
-                    &acc_contract,
+                    &acc_contract.0,
                     &payload,
                     self.signature,
                     &self.invocation_tracker.root_authorized_invocation,
                 )?;
+            }
+            _ => {
+                return Err(host.err(
+                    ScErrorType::Auth,
+                    ScErrorCode::InvalidInput,
+                    "unsupported address type for authentication",
+                    &[],
+                ));
             }
         }
         Ok(())
@@ -2075,7 +2083,7 @@ impl AccountAuthorizationTracker {
             // We only know for sure that the contract instance and Wasm will be
             // loaded.
             ScAddress::Contract(contract_id) => {
-                let instance_key = host.contract_instance_ledger_key(&contract_id)?;
+                let instance_key = host.contract_instance_ledger_key(&contract_id.0)?;
                 let entry = host
                     .try_borrow_storage_mut()?
                     .try_get(&instance_key, host, None)?;
@@ -2110,6 +2118,7 @@ impl AccountAuthorizationTracker {
                     ContractExecutable::StellarAsset => (),
                 }
             }
+            _ => (),
         }
         Ok(())
     }
@@ -2158,7 +2167,7 @@ impl InvokerContractAuthorizationTracker {
         host: &Host,
         invoker_auth_entry: Val,
     ) -> Result<Self, HostError> {
-        let invoker_sc_addr = ScAddress::Contract(host.get_current_contract_id_internal()?);
+        let invoker_sc_addr = ScAddress::Contract(xdr::ContractId(host.get_current_contract_id_internal()?));
         let authorized_invocation = invoker_contract_auth_to_authorized_invocation(
             host,
             &invoker_sc_addr,

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1753,8 +1753,11 @@ impl AccountAuthorizationTracker {
                     Val::VOID.into(),
                     true,
                 ),
-                // NB: CAP-71 AddressV2 wraps the same SorobanAddressCredentials as Address
-                // and is the going-forward standard address credential; handle identically.
+                // NB: CAP-71 AddressV2 wraps the same SorobanAddressCredentials as Address.
+                // Mercury runs retroshades in recording mode only (no signature verification),
+                // so reusing the Address path is safe here. NB: enforcing-mode verification of
+                // AddressV2 needs the CAP-71 address-bound signature preimage
+                // (HashIdPreimageSorobanAuthorizationWithAddress), NOT implemented here. See MER-059.
                 SorobanCredentials::Address(address_creds)
                 | SorobanCredentials::AddressV2(address_creds) => (
                     host.add_host_object(address_creds.address)?,

--- a/soroban-env-host/src/auth.rs
+++ b/soroban-env-host/src/auth.rs
@@ -1753,7 +1753,10 @@ impl AccountAuthorizationTracker {
                     Val::VOID.into(),
                     true,
                 ),
-                SorobanCredentials::Address(address_creds) => (
+                // NB: CAP-71 AddressV2 wraps the same SorobanAddressCredentials as Address
+                // and is the going-forward standard address credential; handle identically.
+                SorobanCredentials::Address(address_creds)
+                | SorobanCredentials::AddressV2(address_creds) => (
                     host.add_host_object(address_creds.address)?,
                     Some((
                         address_creds.nonce,
@@ -1762,6 +1765,16 @@ impl AccountAuthorizationTracker {
                     host.to_host_val(&address_creds.signature)?,
                     false,
                 ),
+                // NB: CAP-71 delegated auth is not implemented in this zephyr host fork.
+                // re-execution of a delegated-auth tx fails here rather than mis-indexing.
+                SorobanCredentials::AddressWithDelegates(_) => {
+                    return Err(host.err(
+                        ScErrorType::Auth,
+                        ScErrorCode::InternalError,
+                        "CAP-71 delegated auth (AddressWithDelegates) is not supported by this host build",
+                        &[],
+                    ));
+                }
             };
         Ok(Self {
             address,

--- a/soroban-env-host/src/budget.rs
+++ b/soroban-env-host/src/budget.rs
@@ -140,6 +140,7 @@ impl Default for BudgetTracker {
                 ContractCostType::Bls12381FrMul => (),
                 ContractCostType::Bls12381FrPow => init_input(), // input is number of bits in the u64 exponent excluding leading zeros
                 ContractCostType::Bls12381FrInv => (),
+                _ => unreachable!("unknown cost type"),
             }
         }
         mt
@@ -598,6 +599,7 @@ impl Default for BudgetImpl {
                     cpu.const_term = 35421;
                     cpu.lin_term = ScaledU64(0);
                 }
+                _ => unreachable!("unknown cost type"),
             }
 
             // define the memory cost model parameters
@@ -890,6 +892,7 @@ impl Default for BudgetImpl {
                     mem.const_term = 0;
                     mem.lin_term = ScaledU64(0);
                 }
+                _ => unreachable!("unknown cost type"),
             }
         }
 

--- a/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
+++ b/soroban-env-host/src/builtin_contracts/stellar_asset_contract/balance.rs
@@ -54,6 +54,11 @@ pub(crate) fn read_balance(e: &Host, addr: Address) -> Result<i128, HostError> {
                 Ok(0)
             }
         }
+        _ => Err(e.error(
+            ContractError::OperationNotSupportedError.into(),
+            "unsupported address type",
+            &[],
+        )),
     }
 }
 
@@ -65,7 +70,7 @@ fn write_contract_balance(
     // We take an unused reference to a "witness" contract-id Hash here, to help
     // ensure this function is only called from a context where `addr` has been
     // matched as an ScAddress::Contract(hash) rather than ScAddress::Account(_)
-    _witness_addr_contract_id: &crate::xdr::Hash,
+    _witness_addr_contract_id: &crate::xdr::ContractId,
 ) -> Result<(), HostError> {
     let key = DataKey::Balance(addr);
     e.put_contract_data(
@@ -130,6 +135,11 @@ pub(crate) fn receive_balance(e: &Host, addr: Address, amount: i128) -> Result<(
             balance.amount = new_balance;
             write_contract_balance(e, addr, balance, &id)
         }
+        _ => Err(e.error(
+            ContractError::OperationNotSupportedError.into(),
+            "unsupported address type",
+            &[],
+        )),
     }
 }
 
@@ -188,6 +198,11 @@ pub(crate) fn spend_balance_no_authorization_check(
             }
             Ok(())
         }
+        _ => Err(e.error(
+            ContractError::OperationNotSupportedError.into(),
+            "unsupported address type",
+            &[],
+        )),
     }
 }
 
@@ -219,6 +234,11 @@ pub(crate) fn is_authorized(e: &Host, addr: Address) -> Result<bool, HostError> 
                 Ok(!is_asset_auth_required(e)?)
             }
         }
+        _ => Err(e.error(
+            ContractError::OperationNotSupportedError.into(),
+            "unsupported address type",
+            &[],
+        )),
     }
 }
 
@@ -257,6 +277,11 @@ pub(crate) fn write_authorization(
                 write_contract_balance(e, addr, balance, &id)
             }
         }
+        _ => Err(e.error(
+            ContractError::OperationNotSupportedError.into(),
+            "unsupported address type",
+            &[],
+        )),
     }
 }
 
@@ -326,6 +351,11 @@ pub(crate) fn check_clawbackable(e: &Host, addr: Address) -> Result<(), HostErro
 
             Ok(())
         }
+        _ => Err(e.error(
+            ContractError::OperationNotSupportedError.into(),
+            "unsupported address type",
+            &[],
+        )),
     }
 }
 

--- a/soroban-env-host/src/builtin_contracts/testutils.rs
+++ b/soroban-env-host/src/builtin_contracts/testutils.rs
@@ -7,11 +7,12 @@ use ed25519_dalek::{Signer, SigningKey};
 use rand::Rng;
 use soroban_env_common::xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
-    AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountId, Hash, HashIdPreimage,
-    HashIdPreimageSorobanAuthorization, InvokeContractArgs, LedgerEntry, LedgerEntryData,
-    LedgerEntryExt, LedgerKey, Liabilities, PublicKey, ScAddress, ScSymbol, ScVal, SequenceNumber,
-    SignerKey, SorobanAddressCredentials, SorobanAuthorizationEntry, SorobanAuthorizedFunction,
-    SorobanAuthorizedInvocation, SorobanCredentials, Thresholds, Uint256,
+    AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountId, ContractId, Hash,
+    HashIdPreimage, HashIdPreimageSorobanAuthorization, InvokeContractArgs, LedgerEntry,
+    LedgerEntryData, LedgerEntryExt, LedgerKey, Liabilities, PublicKey, ScAddress, ScSymbol,
+    ScVal, SequenceNumber, SignerKey, SorobanAddressCredentials, SorobanAuthorizationEntry,
+    SorobanAuthorizedFunction, SorobanAuthorizedInvocation, SorobanCredentials, Thresholds,
+    Uint256,
 };
 use soroban_env_common::{EnvBase, TryFromVal, Val};
 
@@ -47,7 +48,7 @@ pub(crate) fn contract_id_to_address(host: &Host, contract_id: [u8; 32]) -> Addr
     Address::try_from_val(
         host,
         &host
-            .add_host_object(ScAddress::Contract(Hash(contract_id)))
+            .add_host_object(ScAddress::Contract(ContractId(Hash(contract_id))))
             .unwrap(),
     )
     .unwrap()
@@ -124,7 +125,7 @@ impl<'a> TestSigner<'a> {
             TestSigner::AccountInvoker(acc_id) => ScAddress::Account(acc_id.clone()),
             TestSigner::Account(acc) => ScAddress::Account(acc.account_id.clone()),
             TestSigner::AccountContract(signer) => signer.address.to_sc_address().unwrap(),
-            TestSigner::ContractInvoker(contract_id) => ScAddress::Contract(contract_id.clone()),
+            TestSigner::ContractInvoker(contract_id) => ScAddress::Contract(ContractId(contract_id.clone())),
         }
     }
 

--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -487,10 +487,13 @@ impl RecordedAuthPayload {
 #[cfg(any(test, feature = "recording_mode"))]
 fn clear_signature(auth_entry: &mut SorobanAuthorizationEntry) {
     match &mut auth_entry.credentials {
-        SorobanCredentials::Address(address_creds) => {
+        SorobanCredentials::Address(address_creds)
+        | SorobanCredentials::AddressV2(address_creds) => {
             address_creds.signature = ScVal::Void;
         }
         SorobanCredentials::SourceAccount => {}
+        // NB: CAP-71 delegated auth unsupported in this fork (see auth.rs); nothing to clear.
+        SorobanCredentials::AddressWithDelegates(_) => {}
     }
 }
 

--- a/soroban-env-host/src/e2e_invoke.rs
+++ b/soroban-env-host/src/e2e_invoke.rs
@@ -628,7 +628,7 @@ pub fn invoke_host_function_in_recording_mode(
     let mut resources = SorobanResources {
         footprint,
         instructions: 0,
-        read_bytes,
+        disk_read_bytes: read_bytes,
         write_bytes: 0,
     };
     let _resources_roundtrip: SorobanResources =

--- a/soroban-env-host/src/e2e_testutils.rs
+++ b/soroban-env-host/src/e2e_testutils.rs
@@ -2,8 +2,9 @@ use crate::vm::ParsedModule;
 use crate::xdr::{
     AccountEntry, AccountEntryExt, AccountId, ContractCodeEntry, ContractCodeEntryExt,
     ContractCodeEntryV1, ContractDataDurability, ContractDataEntry, ContractExecutable,
-    ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgs, CreateContractArgsV2,
-    ExtensionPoint, HashIdPreimage, HashIdPreimageContractId, HostFunction, InvokeContractArgs,
+    ContractId, ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgs,
+    CreateContractArgsV2,
+    ExtensionPoint, Hash, HashIdPreimage, HashIdPreimageContractId, HostFunction, InvokeContractArgs,
     LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerKey, LedgerKeyContractCode,
     LedgerKeyContractData, Limits, PublicKey, ScAddress, ScBytes, ScContractInstance, ScMapEntry,
     ScSymbol, ScVal, SequenceNumber, SorobanAddressCredentials, SorobanAuthorizationEntry,
@@ -153,11 +154,9 @@ impl CreateContractData {
             contract_id_preimage: contract_id_preimage.clone(),
             executable: ContractExecutable::Wasm(get_wasm_hash(wasm).try_into().unwrap()),
         });
-        let contract_address = ScAddress::Contract(
-            get_contract_id_hash(&contract_id_preimage)
-                .try_into()
-                .unwrap(),
-        );
+        let contract_address = ScAddress::Contract(ContractId(Hash(
+            get_contract_id_hash(&contract_id_preimage),
+        )));
         let contract_key = LedgerKey::ContractData(LedgerKeyContractData {
             contract: contract_address.clone(),
             key: ScVal::LedgerKeyContractInstance,

--- a/soroban-env-host/src/events/internal.rs
+++ b/soroban-env-host/src/events/internal.rs
@@ -25,7 +25,7 @@ impl InternalContractEvent {
         let topics = host.vecobject_to_scval_vec(self.topics)?;
         let data = host.from_host_val(self.data)?;
         let contract_id = match self.contract_id {
-            Some(id) => Some(host.hash_from_bytesobj_input("contract_id", id)?),
+            Some(id) => Some(xdr::ContractId(host.hash_from_bytesobj_input("contract_id", id)?)),
             None => None,
         };
         Ok(xdr::ContractEvent {
@@ -141,7 +141,7 @@ impl InternalDiagnosticEvent {
         };
         Ok(xdr::ContractEvent {
             ext: xdr::ExtensionPoint::V0,
-            contract_id: self.contract_id.metered_clone(host)?,
+            contract_id: self.contract_id.metered_clone(host)?.map(xdr::ContractId),
             type_: xdr::ContractEventType::Diagnostic,
             body: xdr::ContractEventBody::V0(xdr::ContractEventV0 { topics, data }),
         })

--- a/soroban-env-host/src/events/mod.rs
+++ b/soroban-env-host/src/events/mod.rs
@@ -33,9 +33,10 @@ fn display_address(addr: &ScAddress, f: &mut std::fmt::Formatter<'_>) -> std::fm
             }
         },
         ScAddress::Contract(hash) => {
-            let strkey = stellar_strkey::Contract(hash.0);
+            let strkey = stellar_strkey::Contract(hash.0.0);
             write!(f, "{}", strkey)
         }
+        _ => write!(f, "<unsupported address type>"),
     }
 }
 
@@ -117,7 +118,7 @@ impl core::fmt::Display for HostEvent {
         match &self.event.contract_id {
             None => (),
             Some(hash) => {
-                let strkey = stellar_strkey::Contract(hash.0);
+                let strkey = stellar_strkey::Contract(hash.0.0);
                 write!(f, "contract:{}, ", strkey)?
             }
         }

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -13,9 +13,9 @@ use crate::{
     vm::{CustomContextVM, ModuleCache},
     xdr::{
         int128_helpers, AccountId, Asset, ContractCostType, ContractEventType, ContractExecutable,
-        ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgsV2, Duration, Hash,
-        LedgerEntryData, PublicKey, ScAddress, ScBytes, ScErrorCode, ScErrorType, ScString,
-        ScSymbol, ScVal, TimePoint, Uint256,
+        ContractId, ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgsV2,
+        Duration, Hash, LedgerEntryData, PublicKey, ScAddress, ScBytes, ScErrorCode, ScErrorType,
+        ScString, ScSymbol, ScVal, TimePoint, Uint256,
     },
     AddressObject, Bool, BytesObject, Compare, ConversionError, EnvBase, Error, LedgerInfo,
     MapObject, Object, StorageType, StringObject, Symbol, SymbolObject, SymbolSmall, TryFromVal,
@@ -1557,9 +1557,9 @@ impl VmCallerEnv for Host {
         _vmcaller: &mut VmCaller<Host>,
     ) -> Result<AddressObject, HostError> {
         // FIXME: cache this and a few other such IDs: https://github.com/stellar/rs-soroban-env/issues/681
-        self.add_host_object(ScAddress::Contract(
+        self.add_host_object(ScAddress::Contract(ContractId(
             self.get_current_contract_id_internal()?,
-        ))
+        )))
     }
 
     fn get_max_live_until_ledger(
@@ -2582,7 +2582,7 @@ impl VmCallerEnv for Host {
         salt: BytesObject,
     ) -> Result<AddressObject, HostError> {
         let hash_id = self.get_contract_id_hash(deployer, salt)?;
-        self.add_host_object(ScAddress::Contract(hash_id))
+        self.add_host_object(ScAddress::Contract(ContractId(hash_id)))
     }
 
     // Notes on metering: covered by the components.
@@ -2593,7 +2593,7 @@ impl VmCallerEnv for Host {
     ) -> Result<AddressObject, HostError> {
         let asset: Asset = self.metered_from_xdr_obj(serialized_asset)?;
         let hash_id = self.get_asset_contract_id_hash(asset)?;
-        self.add_host_object(ScAddress::Contract(hash_id))
+        self.add_host_object(ScAddress::Contract(ContractId(hash_id)))
     }
 
     fn upload_wasm(
@@ -3482,9 +3482,17 @@ impl VmCallerEnv for Host {
                     );
                     strkey
                 }
-                ScAddress::Contract(Hash(h)) => stellar_strkey::Strkey::Contract(
+                ScAddress::Contract(ContractId(Hash(h))) => stellar_strkey::Strkey::Contract(
                     stellar_strkey::Contract(h.metered_clone(self)?),
                 ),
+                _ => {
+                    return Err(self.err(
+                        ScErrorType::Value,
+                        ScErrorCode::InvalidInput,
+                        "unsupported address type for strkey conversion",
+                        &[],
+                    ));
+                }
             };
             Ok(strkey.to_string())
         })?;
@@ -3546,7 +3554,7 @@ impl VmCallerEnv for Host {
                     PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)),
                 ))),
 
-                stellar_strkey::Strkey::Contract(c) => Ok(ScAddress::Contract(Hash(c.0))),
+                stellar_strkey::Strkey::Contract(c) => Ok(ScAddress::Contract(ContractId(Hash(c.0)))),
                 _ => {
                     return Err(self.err(
                         ScErrorType::Value,

--- a/soroban-env-host/src/host.rs
+++ b/soroban-env-host/src/host.rs
@@ -795,7 +795,6 @@ impl Host {
     }
 
     pub(crate) fn check_ledger_protocol_supported(&self) -> Result<(), HostError> {
-        use soroban_env_common::meta;
         //let proto = self.get_ledger_protocol_version()?;
         // There are some protocol-gating tests that want to register
         // old-protocol contracts and run them in the new host. We allow this in

--- a/soroban-env-host/src/host/conversion.rs
+++ b/soroban-env-host/src/host/conversion.rs
@@ -147,7 +147,7 @@ impl Host {
         durability: ContractDataDurability,
     ) -> Result<Rc<LedgerKey>, HostError> {
         let contract_id = self.get_current_contract_id_internal()?;
-        self.storage_key_for_address(ScAddress::Contract(contract_id), key, durability)
+        self.storage_key_for_address(ScAddress::Contract(xdr::ContractId(contract_id)), key, durability)
     }
 
     /// Converts a [`Val`] to an [`ScVal`] and combines it with the currently-executing

--- a/soroban-env-host/src/host/data_helper.rs
+++ b/soroban-env-host/src/host/data_helper.rs
@@ -9,7 +9,7 @@ use crate::{
     vm::VersionedContractCodeCostInputs,
     xdr::{
         AccountEntry, AccountId, Asset, BytesM, ContractCodeEntry, ContractDataDurability,
-        ContractDataEntry, ContractExecutable, ContractIdPreimage, ExtensionPoint, Hash,
+        ContractDataEntry, ContractExecutable, ContractId, ContractIdPreimage, ExtensionPoint, Hash,
         HashIdPreimage, HashIdPreimageContractId, LedgerEntry, LedgerEntryData, LedgerEntryExt,
         LedgerKey, LedgerKeyAccount, LedgerKeyContractCode, LedgerKeyContractData,
         LedgerKeyTrustLine, PublicKey, ScAddress, ScContractInstance, ScErrorCode, ScErrorType,
@@ -81,7 +81,7 @@ impl Host {
             LedgerKey::ContractData(LedgerKeyContractData {
                 key: ScVal::LedgerKeyContractInstance,
                 durability: ContractDataDurability::Persistent,
-                contract: ScAddress::Contract(contract_id),
+                contract: ScAddress::Contract(ContractId(contract_id)),
             }),
             self,
         )
@@ -220,7 +220,7 @@ impl Host {
             )?;
         } else {
             let data = ContractDataEntry {
-                contract: ScAddress::Contract(contract_id.metered_clone(self)?),
+                contract: ScAddress::Contract(ContractId(contract_id.metered_clone(self)?)),
                 key: ScVal::LedgerKeyContractInstance,
                 val: ScVal::ContractInstance(ScContractInstance {
                     executable: executable.ok_or_else(|| {
@@ -450,7 +450,13 @@ impl Host {
                 "not a contract address",
                 &[],
             )),
-            ScAddress::Contract(contract_id) => Ok(contract_id),
+            ScAddress::Contract(contract_id) => Ok(contract_id.0),
+            _ => Err(self.err(
+                ScErrorType::Object,
+                ScErrorCode::InvalidInput,
+                "not a contract address",
+                &[],
+            )),
         }
     }
 
@@ -505,7 +511,7 @@ impl Host {
             )?;
         } else {
             let data = ContractDataEntry {
-                contract: ScAddress::Contract(self.get_current_contract_id_internal()?),
+                contract: ScAddress::Contract(ContractId(self.get_current_contract_id_internal()?)),
                 key: self.from_host_val(k)?,
                 val: self.from_host_val(v)?,
                 durability,

--- a/soroban-env-host/src/host/frame.rs
+++ b/soroban-env-host/src/host/frame.rs
@@ -1027,7 +1027,7 @@ impl Host {
                     let function_name: Symbol = invoke_args.function_name.try_into_val(self)?;
                     let args = self.scvals_to_val_vec(invoke_args.args.as_slice())?;
                     self.call_n_internal(
-                        contract_id,
+                        &contract_id.0,
                         function_name,
                         args.as_slice(),
                         CallParams::default_external_call(),

--- a/soroban-env-host/src/host/lifecycle.rs
+++ b/soroban-env-host/src/host/lifecycle.rs
@@ -6,9 +6,9 @@ use crate::{
     },
     vm::Vm,
     xdr::{
-        Asset, ContractCodeEntry, ContractDataDurability, ContractExecutable, ContractIdPreimage,
-        ContractIdPreimageFromAddress, CreateContractArgsV2, ExtensionPoint, Hash, LedgerKey,
-        LedgerKeyContractCode, ScAddress, ScErrorCode, ScErrorType,
+        Asset, ContractCodeEntry, ContractDataDurability, ContractExecutable, ContractId,
+        ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgsV2, ExtensionPoint,
+        Hash, LedgerKey, LedgerKeyContractCode, ScAddress, ScErrorCode, ScErrorType,
     },
     AddressObject, BytesObject, Host, HostError, Symbol, TryFromVal, TryIntoVal, Val,
 };
@@ -184,7 +184,7 @@ impl Host {
         if matches!(args.executable, ContractExecutable::Wasm(_)) {
             self.call_constructor(&contract_id, constructor_args)?;
         }
-        self.add_host_object(ScAddress::Contract(contract_id))
+        self.add_host_object(ScAddress::Contract(ContractId(contract_id)))
     }
 
     pub(crate) fn get_contract_id_hash(

--- a/soroban-env-host/src/host/mem_helper.rs
+++ b/soroban-env-host/src/host/mem_helper.rs
@@ -98,7 +98,7 @@ impl Host {
         m: &'a M,
         pos: U32Val,
         len: U32Val,
-    ) -> MemFnArgsCustomVm<M> {
+    ) -> MemFnArgsCustomVm<'a, M> {
         let pos: u32 = pos.into();
         let len: u32 = len.into();
 
@@ -110,7 +110,7 @@ impl Host {
         m: &'a mut M,
         pos: U32Val,
         len: U32Val,
-    ) -> MemFnArgsCustomVmMut<M> {
+    ) -> MemFnArgsCustomVmMut<'a, M> {
         let pos: u32 = pos.into();
         let len: u32 = len.into();
 

--- a/soroban-env-host/src/test/e2e_tests.rs
+++ b/soroban-env-host/src/test/e2e_tests.rs
@@ -109,7 +109,8 @@ fn sign_auth_entry(
 
     match &mut out.credentials {
         SorobanCredentials::SourceAccount => {}
-        SorobanCredentials::Address(creds) => {
+        SorobanCredentials::AddressWithDelegates(_) => {}
+        SorobanCredentials::Address(creds) | SorobanCredentials::AddressV2(creds) => {
             let signature_payload_preimage =
                 HashIdPreimage::SorobanAuthorization(HashIdPreimageSorobanAuthorization {
                     network_id: ledger_info.network_id.try_into().unwrap(),

--- a/soroban-env-host/src/testutils.rs
+++ b/soroban-env-host/src/testutils.rs
@@ -355,7 +355,7 @@ impl Host {
         let test = SymbolSmall::try_from_str("test").unwrap();
 
         // First step: insert all the data values in question into the storage map.
-        host.with_test_contract_frame(contract_hash.clone(), test.into(), || {
+        host.with_test_contract_frame(contract_hash.0.clone(), test.into(), || {
             for (k, (t, _)) in data_keys.iter() {
                 let v = host.to_host_val(k).unwrap();
                 host.put_contract_data(v, v, *t).unwrap();

--- a/soroban-env-macros/Cargo.toml
+++ b/soroban-env-macros/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
-stellar-xdr = { workspace = true, features = ["curr", "std"] }
+stellar-xdr = { workspace = true, features = ["std"] }
 syn = {version="2.0.39",features=["full"]}
 quote = "1.0.35"
 proc-macro2 = "1.0.69"
@@ -22,7 +22,7 @@ serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
 
 [features]
-next = ["stellar-xdr/next"]
+next = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/soroban-env-macros/src/lib.rs
+++ b/soroban-env-macros/src/lib.rs
@@ -11,11 +11,8 @@ use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{parse::Parse, parse_macro_input, Ident, LitInt, LitStr, Token};
 
-// Import the XDR definitions of a specific version -- curr or next -- of the xdr crate.
-#[cfg(not(feature = "next"))]
-use stellar_xdr::curr as xdr;
-#[cfg(feature = "next")]
-use stellar_xdr::next as xdr;
+// stellar-xdr v27 removed the curr/next module split; types live flat at the crate root.
+use stellar_xdr as xdr;
 
 use crate::xdr::{Limits, ScEnvMetaEntry, ScEnvMetaEntryInterfaceVersion, WriteXdr};
 

--- a/soroban-simulation/src/network_config.rs
+++ b/soroban-simulation/src/network_config.rs
@@ -81,10 +81,10 @@ impl NetworkConfig {
         let memory_cost_params = load_setting!(snapshot, ContractCostParamsMemoryBytes);
 
         let write_fee_configuration = WriteFeeConfiguration {
-            bucket_list_target_size_bytes: ledger_cost.bucket_list_target_size_bytes,
-            write_fee_1kb_bucket_list_low: ledger_cost.write_fee1_kb_bucket_list_low,
-            write_fee_1kb_bucket_list_high: ledger_cost.write_fee1_kb_bucket_list_high,
-            bucket_list_write_fee_growth_factor: ledger_cost.bucket_list_write_fee_growth_factor,
+            bucket_list_target_size_bytes: ledger_cost.soroban_state_target_size_bytes,
+            write_fee_1kb_bucket_list_low: ledger_cost.rent_fee1_kb_soroban_state_size_low,
+            write_fee_1kb_bucket_list_high: ledger_cost.rent_fee1_kb_soroban_state_size_high,
+            bucket_list_write_fee_growth_factor: ledger_cost.soroban_state_rent_fee_growth_factor,
         };
         let bucket_list_size: i64 = bucket_list_size
             .try_into()
@@ -94,9 +94,9 @@ impl NetworkConfig {
 
         let fee_configuration = FeeConfiguration {
             fee_per_instruction_increment: compute.fee_rate_per_instructions_increment,
-            fee_per_read_entry: ledger_cost.fee_read_ledger_entry,
+            fee_per_read_entry: ledger_cost.fee_disk_read_ledger_entry,
             fee_per_write_entry: ledger_cost.fee_write_ledger_entry,
-            fee_per_read_1kb: ledger_cost.fee_read1_kb,
+            fee_per_read_1kb: ledger_cost.fee_disk_read1_kb,
             fee_per_write_1kb: write_fee_per_1kb,
             fee_per_historical_1kb: historical_data.fee_historical1_kb,
             fee_per_contract_event_1kb: events.fee_contract_events1_kb,

--- a/soroban-simulation/src/resources.rs
+++ b/soroban-simulation/src/resources.rs
@@ -27,7 +27,7 @@ use std::rc::Rc;
 impl SimulationAdjustmentConfig {
     fn adjust_resources(&self, resources: &mut SorobanResources) {
         resources.instructions = self.instructions.adjust_u32(resources.instructions);
-        resources.read_bytes = self.read_bytes.adjust_u32(resources.read_bytes);
+        resources.disk_read_bytes = self.read_bytes.adjust_u32(resources.disk_read_bytes);
         resources.write_bytes = self.write_bytes.adjust_u32(resources.write_bytes);
     }
 }
@@ -95,7 +95,7 @@ pub fn compute_adjusted_transaction_resources(
             + simulated_operation_resources.footprint.read_write.len())
             as u32,
         write_entries: simulated_operation_resources.footprint.read_write.len() as u32,
-        read_bytes: simulated_operation_resources.read_bytes,
+        read_bytes: simulated_operation_resources.disk_read_bytes,
         write_bytes: simulated_operation_resources.write_bytes,
         transaction_size_bytes: adjustment_config.tx_size.adjust_u32(
             estimate_max_transaction_size_for_operation(operation, &simulated_operation_resources)
@@ -136,7 +136,7 @@ pub fn simulate_invoke_host_function_op_resources(
     let resources = SorobanResources {
         footprint,
         instructions: simulated_instructions,
-        read_bytes,
+        disk_read_bytes: read_bytes,
         write_bytes,
     };
     let rent_changes = extract_rent_changes(ledger_changes);
@@ -184,7 +184,7 @@ pub(crate) fn simulate_extend_ttl_op_resources(
             read_write: Default::default(),
         },
         instructions: 0,
-        read_bytes,
+        disk_read_bytes: read_bytes,
         write_bytes: 0,
     };
     Ok((resources, rent_changes))
@@ -241,7 +241,7 @@ pub(crate) fn simulate_restore_op_resources(
             read_write: restored_keys.try_into()?,
         },
         instructions: 0,
-        read_bytes: restored_bytes,
+        disk_read_bytes: restored_bytes,
         write_bytes: restored_bytes,
     };
     Ok((resources, rent_changes))
@@ -296,7 +296,7 @@ fn estimate_max_transaction_size_for_operation(
                 resources: SorobanResources {
                     footprint: resources.footprint.clone(),
                     instructions: 0,
-                    read_bytes: 0,
+                    disk_read_bytes: 0,
                     write_bytes: 0,
                 },
                 resource_fee: 0,

--- a/soroban-simulation/src/simulation.rs
+++ b/soroban-simulation/src/simulation.rs
@@ -347,7 +347,7 @@ fn create_transaction_data(
     resource_fee: i64,
 ) -> SorobanTransactionData {
     SorobanTransactionData {
-        resources: SorobanResources { footprint: resources.footprint, instructions: resources.instructions + 10000, read_bytes: resources.read_bytes + 200, write_bytes: resources.write_bytes + 200 },
+        resources: SorobanResources { footprint: resources.footprint, instructions: resources.instructions + 10000, disk_read_bytes: resources.disk_read_bytes + 200, write_bytes: resources.write_bytes + 200 },
         resource_fee: resource_fee + 1440500,
         ext: SorobanTransactionDataExt::V0,
     }


### PR DESCRIPTION
Protocol 26 upgrade changes for the Mercury stack.

## Changes

- stellar-xdr workspace dep bumped from `=22.1.2` to `=26.0.0`
- `ContractEvent.contract_id`: `Option<Hash>` → `Option<ContractId>` across host, events, auth, builtins
- `ScAddress::Contract` now takes `ContractId` not `Hash`
- `SorobanResources.read_bytes` → `disk_read_bytes`
- `ConfigSettingContractLedgerCostV0` field renames (`bucket_list_*` → `soroban_state_*`, `fee_read_*` → `fee_disk_read_*`)
- New `ScAddress` variants (`MuxedAccount`, `ClaimableBalance`, `LiquidityPool`) handled with wildcard arms
- New `ContractCostType` variants (Bn254 ops from CAP-0080) handled